### PR TITLE
add aarch64 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,8 @@ jobs:
         - { target: "x86_64-unknown-linux-musl", install_openssl_args: "linux-x86_64 x86_64-linux-musl-"}
         - { target: "armv7-unknown-linux-gnueabihf", install_openssl_args: "linux-armv4 arm-linux-gnueabihf-"}
         - { target: "armv7-unknown-linux-musleabihf", install_openssl_args: "linux-armv4 arm-linux-musleabihf-"}
+        - { target: "aarch64-unknown-linux-gnu", install_openssl_args: "linux-aarch64 aarch64-linux-gnu-"}
+        - { target: "aarch64-unknown-linux-musl", install_openssl_args: "linux-aarch64 aarch64-linux-musl-"}
 
     name: build (${{ matrix.target}})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ubuntu provides aarch64 images for rpi 3 and up. Add support for it.

While installing sheldon:
```
info: latest release: 0.5.0
error: current target aarch64-unknown-linux-gnu is not available for download
```

uname -a:
```
 -> uname -a
Linux pi 5.4.0-1008-raspi #8-Ubuntu SMP Wed Apr 8 11:13:06 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
```